### PR TITLE
update speedtest-cli call

### DIFF
--- a/bin/speedtest-csv
+++ b/bin/speedtest-csv
@@ -155,7 +155,7 @@ else
         mdebug "Reusing existing results: $log"
     else
         # Query Speedtest
-	cmd="speedtest-cli $opts"
+	cmd="/usr/local/bin/speedtest-cli $opts"
         mdebug "Querying Speedtest using '$cmd'"
         $cmd > $log
 	status=$?


### PR DESCRIPTION
Avoid all the mess of ```$PATH``` variable when placed in a cronjob due to lack of ```/usr/local/bin``` for the ```speedtest-cli``` cmd.
Avoid things like : 
```
* * * * * PATH=$PATH:/usr/local/bin && export PATH && /path/to/speedtest-csv
```